### PR TITLE
Fix memory leak in CircularBuffer class

### DIFF
--- a/include/diff_drive_lib/circular_buffer.hpp
+++ b/include/diff_drive_lib/circular_buffer.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <atomic>
 
 namespace diff_drive_lib {
 
@@ -10,14 +9,14 @@ class CircularBuffer {
   T* values_;
   size_t size_;
   size_t iter_;
-  std::atomic_bool dynamicAlloc_;
+  const bool dynamic_alloc_;
 
  public:
   explicit CircularBuffer(size_t size)
-      : values_(new T[size]()), size_(size), iter_(0), dynamicAlloc_(true) {}
+      : values_(new T[size]()), size_(size), iter_(0), dynamic_alloc_(true) {}
 
   CircularBuffer(size_t size, T* buffer)
-      : values_(buffer), size_(size), iter_(0), dynamicAlloc_(false) {}
+      : values_(buffer), size_(size), iter_(0), dynamic_alloc_(false) {}
 
   ~CircularBuffer() {
     if (dynamicAlloc_.load())

--- a/include/diff_drive_lib/circular_buffer.hpp
+++ b/include/diff_drive_lib/circular_buffer.hpp
@@ -9,16 +9,18 @@ class CircularBuffer {
   T* values_;
   size_t size_;
   size_t iter_;
+  std::atomic_bool dynamicAlloc_;
 
  public:
   explicit CircularBuffer(size_t size)
-      : values_(new T[size]()), size_(size), iter_(0) {}
+      : values_(new T[size]()), size_(size), iter_(0), dynamicAlloc_(true) {}
 
   CircularBuffer(size_t size, T* buffer)
-      : values_(buffer), size_(size), iter_(0) {}
+      : values_(buffer), size_(size), iter_(0), dynamicAlloc_(false) {}
 
   ~CircularBuffer() {
-    delete values_;
+    if (dynamicAlloc_.load())
+      delete values_;
   }
 
   T push_back(T val) {

--- a/include/diff_drive_lib/circular_buffer.hpp
+++ b/include/diff_drive_lib/circular_buffer.hpp
@@ -19,7 +19,7 @@ class CircularBuffer {
       : values_(buffer), size_(size), iter_(0), dynamic_alloc_(false) {}
 
   ~CircularBuffer() {
-    if (dynamicAlloc_.load())
+    if (dynamic_alloc_)
       delete values_;
   }
 

--- a/include/diff_drive_lib/circular_buffer.hpp
+++ b/include/diff_drive_lib/circular_buffer.hpp
@@ -17,6 +17,10 @@ class CircularBuffer {
   CircularBuffer(size_t size, T* buffer)
       : values_(buffer), size_(size), iter_(0) {}
 
+  ~CircularBuffer() {
+    delete values_;
+  }
+
   T push_back(T val) {
     T tmp = values_[iter_];
     values_[iter_++] = val;

--- a/include/diff_drive_lib/circular_buffer.hpp
+++ b/include/diff_drive_lib/circular_buffer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <atomic>
 
 namespace diff_drive_lib {
 


### PR DESCRIPTION
CircularBuffer is allocating some memory dynamically in its constructor, but the memory was never freed. So adding a destructor wich calls delete on the dynamically allocated pointer.